### PR TITLE
Move lint-staged config to own file

### DIFF
--- a/.lintstagedrc.json
+++ b/.lintstagedrc.json
@@ -1,0 +1,3 @@
+{
+  "*.{js,flow,ts,tsx,json,css,md}": "prettier --write"
+}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Updating TypeScript to v4.9 has fixed Rollup not being able to output type declarations, so the npm script
   `build:ts-decl` is removed.
 - TypeScript declarations are now available under `lib` instead of `types`.
+- Move lint-staged configuration to its own file `.lintstagedrc.json`.
 - Bump `husky` to version `8.0.3`.
 - Bump `lint-staged` to version `13.1.2`.
 - Bump `typescript` to version `4.9.5`.

--- a/package.json
+++ b/package.json
@@ -48,8 +48,5 @@
   },
   "peerDependencies": {
     "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
-  },
-  "lint-staged": {
-    "*.{js,flow,ts,tsx,json,css,md}": "prettier --write"
   }
 }


### PR DESCRIPTION
This allows a cleaner `package.json`.